### PR TITLE
Updated file to automate TRIM input

### DIFF
--- a/contrib/SRIM-2013/RUNTRIMtest.sh
+++ b/contrib/SRIM-2013/RUNTRIMtest.sh
@@ -1,20 +1,20 @@
-#!/bin/bash                                                                                      
+#!/bin/bash                                                                                     
 
 
-for i in {1..2..1}  ## energies
+for energies in {1..2}  ## energies
 do
-        for j in {1..2..1}  ##sample thickness
-	do
-	    for k in {1..2..1} ##coolant thickness
-            do
-                        sed 's/<BEAMENERGY>/"$i"/'  TRIM-Script-sample-SS316.IN > TRIM1.IN
-                        sed 's/<SAMPTHICK>/"$j"/' TRIM1.IN > TRIM2.IN
-                        sed 's/<COOLTHICK>/"$k"/' TRIM2.IN > TRIM.IN
-                        wine TRIM.exe
-			touch vacancy_files/VAC-SS316COOLANT-CTHICK-"$k"-SAMPLETHICK-"$j"-E-"$i".txt
-                        cp VACANCY.txt vacancy_files/VAC-SS316COOLANT-CTHICK-"$k"-SAMPLETHICK-"$j"-E-"$i".txt
-			touch range_files/RANGE-SS316COOLANT-CTHICK-"$k"-SAMPLETHICK-"$j"-E-"$i".txt
-                        cp RANGE.txt range_files/RANGE-SS316COOLANT-CTHICK-"$k"-SAMPLETHICK-"$j"-E-"$i".txt
-                done
-        done
+    for j in {1..2}  ##sample thickness
+    do
+	for k in {1..2} ##coolant thickness
+        do
+	    sed "s/<BEAMENERGY>/$energies/"  TRIM-Script-sample-SS316.IN > TRIM1.IN
+            sed "s/<SAMPTHICK>/$j/" TRIM1.IN > TRIM2.IN
+            sed "s/<COOLTHICK>/$k/" TRIM2.IN > TRIM.IN
+            wine TRIM.exe
+	    touch vacancy_files/VAC-SS316COOLANT-CTHICK-"$k"-SAMPLETHICK-"$j"-E-"$energies".txt
+            cp VACANCY.txt vacancy_files/VAC-SS316COOLANT-CTHICK-"$k"-SAMPLETHICK-"$j"-E-"$energies".txt
+	    touch range_files/RANGE-SS316COOLANT-CTHICK-"$k"-SAMPLETHICK-"$j"-E-"$energies".txt
+            cp RANGE.txt range_files/RANGE-SS316COOLANT-CTHICK-"$k"-SAMPLETHICK-"$j"-E-"$energies".txt
+	done
+    done
 done

--- a/contrib/SRIM-2013/RUNTRIMtest.sh
+++ b/contrib/SRIM-2013/RUNTRIMtest.sh
@@ -1,11 +1,11 @@
 #!/bin/bash                                                                                     
 
 
-for energies in {1..2}  ## energies
+for energies in {10000..40000..5000}  ## energies
 do
-    for j in {1..2}  ##sample thickness
+    for j in {0.5..3..0.5}  ##sample thickness
     do
-	for k in {1..2} ##coolant thickness
+	for k in {0.5..3..0.5} ##coolant thickness
         do
 	    sed "s/<BEAMENERGY>/$energies/"  TRIM-Script-sample-SS316.IN > TRIM1.IN
             sed "s/<SAMPTHICK>/$j/" TRIM1.IN > TRIM2.IN

--- a/contrib/SRIM-2013/RUNTRIMtest.sh
+++ b/contrib/SRIM-2013/RUNTRIMtest.sh
@@ -2,7 +2,7 @@
 
 
 for i in {1..2..1}  ## energies
-do         
+do
         for j in {1..2..1}  ##sample thickness
 	do
 	    for k in {1..2..1} ##coolant thickness

--- a/contrib/SRIM-2013/RUNTRIMtest.sh
+++ b/contrib/SRIM-2013/RUNTRIMtest.sh
@@ -1,0 +1,20 @@
+#!/bin/bash                                                                                      
+
+
+for i in {1..2..1}  ## energies
+do         
+        for j in {1..2..1}  ##sample thickness
+	do
+	    for k in {1..2..1} ##coolant thickness
+            do
+                        sed 's/<BEAMENERGY>/"$i"/'  TRIM-Script-sample-SS316.IN > TRIM1.IN
+                        sed 's/<SAMPTHICK>/"$j"/' TRIM1.IN > TRIM2.IN
+                        sed 's/<COOLTHICK>/"$k"/' TRIM2.IN > TRIM.IN
+                        wine TRIM.exe
+			touch vacancy_files/VAC-SS316COOLANT-CTHICK-"$k"-SAMPLETHICK-"$j"-E-"$i".txt
+                        cp VACANCY.txt vacancy_files/VAC-SS316COOLANT-CTHICK-"$k"-SAMPLETHICK-"$j"-E-"$i".txt
+			touch range_files/RANGE-SS316COOLANT-CTHICK-"$k"-SAMPLETHICK-"$j"-E-"$i".txt
+                        cp RANGE.txt range_files/RANGE-SS316COOLANT-CTHICK-"$k"-SAMPLETHICK-"$j"-E-"$i".txt
+                done
+        done
+done

--- a/contrib/SRIM-2013/TRIM.IN
+++ b/contrib/SRIM-2013/TRIM.IN
@@ -1,30 +1,46 @@
 ==> SRIM-2013.00 This file controls TRIM Calculations.
 Ion: Z1 ,  M1,  Energy (keV), Angle,Number,Bragg Corr,AutoSave Number.
-     1   1.008       40000       0  100000        1    10000
+     1   1.008         2       0   25000        1    10000
 Cascades(1=No;2=Full;3=Sputt;4-5=Ions;6-7=Neutrons), Random Number Seed, Reminders
                       1                                   0       0
 Diskfiles (0=no,1=yes): Ranges, Backscatt, Transmit, Sputtered, Collisions(1=Ion;2=Ion+Recoils), Special EXYZ.txt file
                           0       0           0       0               0                               0
 Target material : Number of Elements & Layers
-"H (10) into Sample-W+Slab-Cu            "       2               2
+"H (10) into Stainless Steel+KNO3+Stainle"      15               5
 PlotType (0-5); Plot Depths: Xmin, Xmax(Ang.) [=0 0 for Viewing Full Target]
-       0                         0           5E+07
+       0                         0           5E+11
 Target Elements:    Z   Mass(amu)
-Atom 1 = W =        74  183.85
-Atom 2 = Cu =       29  63.546
-Layer   Layer Name /               Width Density     W(74)  Cu(29)
-Numb.   Description                (Ang) (g/cm3)    Stoich  Stoich
- 1      "Sample-W"           5000000  19.3       1       0
- 2      "Slab-Cu"           45000000  8.92       0       1
+Atom 1 = Cr =      24  51.996
+Atom 2 = Fe =      26  55.847
+Atom 3 = Ni =      28   58.69
+Atom 4 = O =       8  15.999
+Atom 5 = N =       7  14.007
+Atom 6 = K =      19  39.098
+Atom 7 = Cr =      24  51.996
+Atom 8 = Fe =      26  55.847
+Atom 9 = Ni =      28   58.69
+Atom 10 = O =       8  15.999
+Atom 11 = N =       7  14.007
+Atom 12 = K =      19  39.098
+Atom 13 = Cr =      24  51.996
+Atom 14 = Fe =      26  55.847
+Atom 15 = Ni =      28   58.69
+Layer   Layer Name /               Width Density    Cr(24)  Fe(26)  Ni(28)    O(8)    N(7)   K(19)  Cr(24)  Fe(26)  Ni(28)    O(8)    N(7)   K(19)  Cr(24)  Fe(26)  Ni(28)
+Numb.   Description                (Ang) (g/cm3)    Stoich  Stoich  Stoich  Stoich  Stoich  Stoich  Stoich  Stoich  Stoich  Stoich  Stoich  Stoich  Stoich  Stoich  Stoich
+ 1      "Stainless Steel"           100000000000  8     .08     .74     .18       0       0       0       0       0       0       0       0       0       0       0       0
+ 2      "KNO3"           2  2.1       0       0       0      .6      .2      .2       0       0       0       0       0       0       0       0       0
+ 3      "Stainless Steel"           2  8       0       0       0       0       0       0     .08     .74     .18       0       0       0       0       0       0
+ 4      "KNO3"           2  2.1       0       0       0       0       0       0       0       0       0      .6      .2      .2       0       0       0
+ 5      "Stainless Steel"           100000000000  8       0       0       0       0       0       0       0       0       0       0       0       0     .08     .74     .18
 0  Target layer phases (0=Solid, 1=Gas)
-0 0 
+0 0 0 0 0 
 Target Compound Corrections (Bragg)
- 1   1  
+ 1   1   1   1   1  
 Individual target atom displacement energies (eV)
-      25      25
+      25      25      25      28      28      25      25      25      25      28      28      25      25      25      25
 Individual target atom lattice binding energies (eV)
-       3       3
+       3       3       3       3       3       3       3       3       3       3       3       3       3       3       3
 Individual target atom surface binding energies (eV)
-    8.68    3.52
+    4.12    4.34    4.46       2       2     .93    4.12    4.34    4.46       2       2     .93    4.12    4.34    4.46
 Stopping Power Version (1=2011, 0=2011)
  0 

--- a/contrib/SRIM-2013/TRIM1.IN
+++ b/contrib/SRIM-2013/TRIM1.IN
@@ -1,6 +1,6 @@
 ==> SRIM-2013.00 This file controls TRIM Calculations.
 Ion: Z1 ,  M1,  Energy (keV), Angle,Number,Bragg Corr,AutoSave Number.
-     1   1.008         "$i"       0   25000        1    10000
+     1   1.008         2       0   25000        1    10000
 Cascades(1=No;2=Full;3=Sputt;4-5=Ions;6-7=Neutrons), Random Number Seed, Reminders
                       1                                   0       0
 Diskfiles (0=no,1=yes): Ranges, Backscatt, Transmit, Sputtered, Collisions(1=Ion;2=Ion+Recoils), Special EXYZ.txt file

--- a/contrib/SRIM-2013/TRIM1.IN
+++ b/contrib/SRIM-2013/TRIM1.IN
@@ -1,0 +1,46 @@
+==> SRIM-2013.00 This file controls TRIM Calculations.
+Ion: Z1 ,  M1,  Energy (keV), Angle,Number,Bragg Corr,AutoSave Number.
+     1   1.008         "$i"       0   25000        1    10000
+Cascades(1=No;2=Full;3=Sputt;4-5=Ions;6-7=Neutrons), Random Number Seed, Reminders
+                      1                                   0       0
+Diskfiles (0=no,1=yes): Ranges, Backscatt, Transmit, Sputtered, Collisions(1=Ion;2=Ion+Recoils), Special EXYZ.txt file
+                          0       0           0       0               0                               0
+Target material : Number of Elements & Layers
+"H (10) into Stainless Steel+KNO3+Stainle"      15               5
+PlotType (0-5); Plot Depths: Xmin, Xmax(Ang.) [=0 0 for Viewing Full Target]
+       0                         0           5E+11
+Target Elements:    Z   Mass(amu)
+Atom 1 = Cr =      24  51.996
+Atom 2 = Fe =      26  55.847
+Atom 3 = Ni =      28   58.69
+Atom 4 = O =       8  15.999
+Atom 5 = N =       7  14.007
+Atom 6 = K =      19  39.098
+Atom 7 = Cr =      24  51.996
+Atom 8 = Fe =      26  55.847
+Atom 9 = Ni =      28   58.69
+Atom 10 = O =       8  15.999
+Atom 11 = N =       7  14.007
+Atom 12 = K =      19  39.098
+Atom 13 = Cr =      24  51.996
+Atom 14 = Fe =      26  55.847
+Atom 15 = Ni =      28   58.69
+Layer   Layer Name /               Width Density    Cr(24)  Fe(26)  Ni(28)    O(8)    N(7)   K(19)  Cr(24)  Fe(26)  Ni(28)    O(8)    N(7)   K(19)  Cr(24)  Fe(26)  Ni(28)
+Numb.   Description                (Ang) (g/cm3)    Stoich  Stoich  Stoich  Stoich  Stoich  Stoich  Stoich  Stoich  Stoich  Stoich  Stoich  Stoich  Stoich  Stoich  Stoich
+ 1      "Stainless Steel"           100000000000  8     .08     .74     .18       0       0       0       0       0       0       0       0       0       0       0       0
+ 2      "KNO3"           <COOLTHICK>  2.1       0       0       0      .6      .2      .2       0       0       0       0       0       0       0       0       0
+ 3      "Stainless Steel"           <SAMPTHICK>  8       0       0       0       0       0       0     .08     .74     .18       0       0       0       0       0       0
+ 4      "KNO3"           <COOLTHICK>  2.1       0       0       0       0       0       0       0       0       0      .6      .2      .2       0       0       0
+ 5      "Stainless Steel"           100000000000  8       0       0       0       0       0       0       0       0       0       0       0       0     .08     .74     .18
+0  Target layer phases (0=Solid, 1=Gas)
+0 0 0 0 0 
+Target Compound Corrections (Bragg)
+ 1   1   1   1   1  
+Individual target atom displacement energies (eV)
+      25      25      25      28      28      25      25      25      25      28      28      25      25      25      25
+Individual target atom lattice binding energies (eV)
+       3       3       3       3       3       3       3       3       3       3       3       3       3       3       3
+Individual target atom surface binding energies (eV)
+    4.12    4.34    4.46       2       2     .93    4.12    4.34    4.46       2       2     .93    4.12    4.34    4.46
+Stopping Power Version (1=2011, 0=2011)
+ 0 

--- a/contrib/SRIM-2013/TRIM2.IN
+++ b/contrib/SRIM-2013/TRIM2.IN
@@ -1,0 +1,46 @@
+==> SRIM-2013.00 This file controls TRIM Calculations.
+Ion: Z1 ,  M1,  Energy (keV), Angle,Number,Bragg Corr,AutoSave Number.
+     1   1.008         "$i"       0   25000        1    10000
+Cascades(1=No;2=Full;3=Sputt;4-5=Ions;6-7=Neutrons), Random Number Seed, Reminders
+                      1                                   0       0
+Diskfiles (0=no,1=yes): Ranges, Backscatt, Transmit, Sputtered, Collisions(1=Ion;2=Ion+Recoils), Special EXYZ.txt file
+                          0       0           0       0               0                               0
+Target material : Number of Elements & Layers
+"H (10) into Stainless Steel+KNO3+Stainle"      15               5
+PlotType (0-5); Plot Depths: Xmin, Xmax(Ang.) [=0 0 for Viewing Full Target]
+       0                         0           5E+11
+Target Elements:    Z   Mass(amu)
+Atom 1 = Cr =      24  51.996
+Atom 2 = Fe =      26  55.847
+Atom 3 = Ni =      28   58.69
+Atom 4 = O =       8  15.999
+Atom 5 = N =       7  14.007
+Atom 6 = K =      19  39.098
+Atom 7 = Cr =      24  51.996
+Atom 8 = Fe =      26  55.847
+Atom 9 = Ni =      28   58.69
+Atom 10 = O =       8  15.999
+Atom 11 = N =       7  14.007
+Atom 12 = K =      19  39.098
+Atom 13 = Cr =      24  51.996
+Atom 14 = Fe =      26  55.847
+Atom 15 = Ni =      28   58.69
+Layer   Layer Name /               Width Density    Cr(24)  Fe(26)  Ni(28)    O(8)    N(7)   K(19)  Cr(24)  Fe(26)  Ni(28)    O(8)    N(7)   K(19)  Cr(24)  Fe(26)  Ni(28)
+Numb.   Description                (Ang) (g/cm3)    Stoich  Stoich  Stoich  Stoich  Stoich  Stoich  Stoich  Stoich  Stoich  Stoich  Stoich  Stoich  Stoich  Stoich  Stoich
+ 1      "Stainless Steel"           100000000000  8     .08     .74     .18       0       0       0       0       0       0       0       0       0       0       0       0
+ 2      "KNO3"           <COOLTHICK>  2.1       0       0       0      .6      .2      .2       0       0       0       0       0       0       0       0       0
+ 3      "Stainless Steel"           "$j"  8       0       0       0       0       0       0     .08     .74     .18       0       0       0       0       0       0
+ 4      "KNO3"           <COOLTHICK>  2.1       0       0       0       0       0       0       0       0       0      .6      .2      .2       0       0       0
+ 5      "Stainless Steel"           100000000000  8       0       0       0       0       0       0       0       0       0       0       0       0     .08     .74     .18
+0  Target layer phases (0=Solid, 1=Gas)
+0 0 0 0 0 
+Target Compound Corrections (Bragg)
+ 1   1   1   1   1  
+Individual target atom displacement energies (eV)
+      25      25      25      28      28      25      25      25      25      28      28      25      25      25      25
+Individual target atom lattice binding energies (eV)
+       3       3       3       3       3       3       3       3       3       3       3       3       3       3       3
+Individual target atom surface binding energies (eV)
+    4.12    4.34    4.46       2       2     .93    4.12    4.34    4.46       2       2     .93    4.12    4.34    4.46
+Stopping Power Version (1=2011, 0=2011)
+ 0 

--- a/contrib/SRIM-2013/TRIM2.IN
+++ b/contrib/SRIM-2013/TRIM2.IN
@@ -1,6 +1,6 @@
 ==> SRIM-2013.00 This file controls TRIM Calculations.
 Ion: Z1 ,  M1,  Energy (keV), Angle,Number,Bragg Corr,AutoSave Number.
-     1   1.008         "$i"       0   25000        1    10000
+     1   1.008         2       0   25000        1    10000
 Cascades(1=No;2=Full;3=Sputt;4-5=Ions;6-7=Neutrons), Random Number Seed, Reminders
                       1                                   0       0
 Diskfiles (0=no,1=yes): Ranges, Backscatt, Transmit, Sputtered, Collisions(1=Ion;2=Ion+Recoils), Special EXYZ.txt file
@@ -29,7 +29,7 @@ Layer   Layer Name /               Width Density    Cr(24)  Fe(26)  Ni(28)    O(
 Numb.   Description                (Ang) (g/cm3)    Stoich  Stoich  Stoich  Stoich  Stoich  Stoich  Stoich  Stoich  Stoich  Stoich  Stoich  Stoich  Stoich  Stoich  Stoich
  1      "Stainless Steel"           100000000000  8     .08     .74     .18       0       0       0       0       0       0       0       0       0       0       0       0
  2      "KNO3"           <COOLTHICK>  2.1       0       0       0      .6      .2      .2       0       0       0       0       0       0       0       0       0
- 3      "Stainless Steel"           "$j"  8       0       0       0       0       0       0     .08     .74     .18       0       0       0       0       0       0
+ 3      "Stainless Steel"           2  8       0       0       0       0       0       0     .08     .74     .18       0       0       0       0       0       0
  4      "KNO3"           <COOLTHICK>  2.1       0       0       0       0       0       0       0       0       0      .6      .2      .2       0       0       0
  5      "Stainless Steel"           100000000000  8       0       0       0       0       0       0       0       0       0       0       0       0     .08     .74     .18
 0  Target layer phases (0=Solid, 1=Gas)


### PR DESCRIPTION
RUNTRIMtest -- file that has the desire energy, coolant thickness, and sample thickness ranges for this project
TRIM1.IN , TRIM2.IN -- these files replace the energy and sample thicknesses. Used to check that RUNTRIMtest works.
